### PR TITLE
Use Nunjucks template engine to share header/footer among all pages

### DIFF
--- a/nunjucks.config.js
+++ b/nunjucks.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    root: './public',
+    data: {},
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "rm dist/*",
+    "clean": "rm -rf dist/* .cache/",
     "start": "parcel serve --no-hmr public/index.njk",
     "build-prod": "parcel build public/index.njk --public-url ./",
     "create-cname": "echo 'pycamp.es' > dist/CNAME",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm dist/*",
-    "start": "parcel public/index.html public/diversity.html",
-    "build-prod": "parcel build public/index.html public/diversity.html --public-url ./",
+    "start": "parcel public/index.njk",
+    "build-prod": "parcel build public/index.njk --public-url ./",
     "create-cname": "echo 'pycamp.es' > dist/CNAME",
     "gh-deploy": "gh-pages -d dist",
     "deploy": "yarn clean && yarn build-prod && yarn create-cname && yarn gh-deploy"
@@ -25,6 +25,8 @@
   },
   "dependencies": {
     "bootstrap": "^4.3.1",
-    "g-sheets-api": "^1.0.3"
+    "g-sheets-api": "^1.0.3",
+    "nunjucks": "^3.2.0",
+    "parcel-plugin-nunjucks": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm dist/*",
-    "start": "parcel public/index.njk",
+    "start": "parcel serve --no-hmr public/index.njk",
     "build-prod": "parcel build public/index.njk --public-url ./",
     "create-cname": "echo 'pycamp.es' > dist/CNAME",
     "gh-deploy": "gh-pages -d dist",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.1",
     "gh-pages": "^2.1.1",
-    "parcel-bundler": "^1.12.3",
+    "parcel-bundler": "^1.12.4",
     "prettier": "^1.18.2",
     "sass": "^1.22.12"
   },

--- a/public/diversity.njk
+++ b/public/diversity.njk
@@ -1,43 +1,15 @@
-<!DOCTYPE html>
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta name="theme-color" content="#000000" />
-    <meta name="robots" content="index,follow" />
-    <meta name="description" content="Pycamp es. Campamento Python España" />
-    <link rel="canonical" href="https://pycamp.es/" />
+{% extends 'layout.njk' %}
 
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Pycampes" />
-    <meta property="og:title" content="PyCamp.ES" />
-    <meta property="og:description" content="Campamento Python España" />
-    <meta property="og:image:width" content="500" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:price:amount" content="" />
-    <meta property="og:price:currency" content="EUR" />
-    <meta name="twitter:card" content="summary_large_image" />
+{% block title %}
+PyCamp España: Diversidad
+{% endblock %}
 
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="shortcut icon" href="/images/camp.svg" />
-
-    <script
-      src="https://kit.fontawesome.com/738e427f6d.js"
-      crossorigin="anonymous"
-    ></script>
-
-    <title>PyCamp España: Diversidad</title>
-  </head>
-
-  <body>
+{% block content %}
     <section>
       <div class="container">
-        <div class="row">
-          <div class="col col-12">
-            <h1 class="display-3 text-center">
+        <div class="row justify-content-center">
+          <div class="col col-12 col-lg-7">
+            <h1 class="text-primary text-center section-title pb-4" style="padding-top: 50px;">
               Código de Conducta
             </h1>
             <p>
@@ -59,10 +31,10 @@
               normas durante el evento.
             </p>
           </div>
-          <div class="col col-12">
-            <h2 class="display-4">
+          <div class="col col-12 col-lg-7">
+            <h3 class="my-4">
               La versión corta
-            </h2>
+            </h3>
             <p>
               Uno de los objetivos de PyCamp es proveer una experiencia libre de
               acoso o discriminación para todos, sin distinciones de género,
@@ -92,10 +64,10 @@
               amistoso.
             </p>
           </div>
-          <div class="col col-12">
-            <h2 class="display-4">
+          <div class="col col-12 col-lg-7">
+            <h3 class="my-4">
               La versión larga
-            </h2>
+            </h3>
 
             <p>
               Acoso incluye comentarios ofensivos relativos a género,
@@ -124,9 +96,9 @@
             </p>
           </div>
 
-          <div class="col col-12">
-            <h2 class="display-4">
-              Información de Contacto
+          <div class="col col-12 col-lg-7">
+            <h2 class="text-primary mt-5 mb-5">
+              Información de contacto
             </h2>
             <p>
               Si eres objeto de acoso, notas que alguien más está siendo
@@ -140,77 +112,17 @@
               </h3>
             </div>
           </div>
-          <div class="col col-12 mb-3">
-            PyCampEs ha decidido utilizar el
+          <div class="text-center small col col-12 col-lg-7 mb-3">
+            PyCamp España ha decidido utilizar el
             <a href="http://diversidad.python.org.ar/">
               código de conducta de la comunidad de Python Argentina.
             </a>
-            Sigue el link para leer mas.
           </div>
         </div>
       </div>
     </section>
-    <!-- Footer -->
-    <footer class="footer bg-secondary">
-      <div class="container py-5">
-        <div class="row">
-          <div class="col-12 h-100 text-center my-auto">
-            <ul class="list-inline mb-0">
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="mailto:pycampes@gmail.com">
-                  <i class="far fa-envelope fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://t.me/pycampes">
-                  <i class="fab fa-telegram fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://www.facebook.com/pycampes">
-                  <i class="fab fa-facebook fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://twitter.com/PyCampES">
-                  <i class="fab fa-twitter-square fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://www.instagram.com/pycampes/">
-                  <i class="fab fa-instagram fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item">
-                <a target="_blank" href="https://pycampes.slack.com">
-                  <i class="fab fa-slack fa-2x fa-fw"></i>
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="row mt-3">
-          <div class="col-12 h-100 text-center my-auto ">
-            <ul class="nav justify-content-center">
-              <li class="nav-item">
-                <a class="nav-link" href="./index.html">Inicio</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="./diversity.html">
-                  Código de conducta
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="./previous_editions.html">
-                  Ediciones Anteriores
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </footer>
+{% endblock %}
 
-    <script src="../src/diversity.js"></script>
-  </body>
-</html>
+{% block extra_footer %}
+<script src="../src/diversity.js"></script>
+{% endblock %}

--- a/public/extra_footer.html
+++ b/public/extra_footer.html
@@ -1,0 +1,15 @@
+    <script
+      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
+      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+      integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
+      integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
+      crossorigin="anonymous"
+    ></script>

--- a/public/index.njk
+++ b/public/index.njk
@@ -1,121 +1,15 @@
-<!DOCTYPE html>
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta name="theme-color" content="#000000" />
-    <meta name="robots" content="index,follow" />
-    <meta name="description" content="PyCamp España" />
-    <link rel="canonical" href="https://pycamp.es/" />
+{% extends 'layout.njk' %}
 
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="PyCamp.ES" />
-    <meta property="og:title" content="PyCamp.ES" />
-    <meta property="og:description" content="PyCamp España" />
-    <meta property="og:image:width" content="500" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:price:amount" content="220" />
-    <meta property="og:price:currency" content="EUR" />
-    <meta name="twitter:card" content="summary_large_image" />
-
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="shortcut icon" href="/images/camp.svg" />
+{% block extra_head %}
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
       integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
       crossorigin=""
     />
-    <script
-      src="https://kit.fontawesome.com/738e427f6d.js"
-      crossorigin="anonymous"
-    ></script>
+{% endblock %}
 
-    <title>PyCamp España</title>
-  </head>
-
-  <body>
-    <!-- Navigation -->
-    <nav
-      class="navbar navbar-expand-lg navbar-light bg-primary sticky-top py-3"
-    >
-      <div class="container">
-        <a class="navbar-brand" href="#"
-          ><img src="images/pycamp-logo2.png" width="200"
-        /></a>
-        <button
-          class="navbar-toggler"
-          type="button"
-          data-toggle="collapse"
-          data-target="#navbarSupportedContent"
-          aria-controls="navbarSupportedContent"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-item">
-              <a class="nav-link" href="#faq">¿Qué es un PyCamp?</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#projects">Proyectos</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#what-to-bring">¿Qué llevo?</a>
-            </li>
-            <li class="nav-item">
-              <a
-                class="nav-link"
-                href="./diversity.html"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Código de conducta
-              </a>
-            </li>
-            <li class="nav-item">
-              <ul class="nav-link list-inline mb-0 text-center">
-                <li class="list-inline-item mr-3">
-                  <a target="_blank" href="mailto:pycampes@gmail.com">
-                    <i class="text-secondary far fa-envelope"></i>
-                  </a>
-                </li>
-                <li class="list-inline-item mr-3">
-                  <a target="_blank" href="https://t.me/pycampes">
-                    <i class="text-secondary fab fa-telegram"></i>
-                  </a>
-                </li>
-                <li class="list-inline-item mr-3">
-                  <a target="_blank" href="https://www.facebook.com/pycampes">
-                    <i class="text-secondary fab fa-facebook"></i>
-                  </a>
-                </li>
-                <li class="list-inline-item mr-3">
-                  <a target="_blank" href="https://twitter.com/PyCampES">
-                    <i class="text-secondary fab fa-twitter-square"></i>
-                  </a>
-                </li>
-                <li class="list-inline-item mr-3">
-                  <a target="_blank" href="https://www.instagram.com/pycampes/">
-                    <i class="text-secondary fab fa-instagram"></i>
-                  </a>
-                </li>
-                <li class="list-inline-item">
-                  <a target="_blank" href="https://pycampes.slack.com">
-                    <i class=" text-secondary fab fa-slack"></i>
-                  </a>
-                </li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
+{% block content %}
     <section id="buy-now">
       <div class="jumbotron jumbotron-fluid mb-0">
         <div class="overlay"></div>
@@ -449,7 +343,7 @@
                   (¡llevan 10 ediciones!) Puedes conocer más proyectos en la
                   sección de
                   <a
-                    href="previous_editions.html"
+                    href="previous_editions.njk"
                     target="_blank"
                     ><b>ediciones anteriores</b></a
                   >.
@@ -803,97 +697,9 @@
         </div>
       </div>
     </section>
-    <!-- Footer -->
-    <footer class="footer bg-secondary">
-      <div class="container py-5">
-        <div class="row">
-          <div class="col-12 h-100 text-center my-auto">
-            <ul class="list-inline mb-0">
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="mailto:pycampes@gmail.com">
-                  <i class="far fa-envelope fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://t.me/pycampes">
-                  <i class="fab fa-telegram fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://www.facebook.com/pycampes">
-                  <i class="fab fa-facebook fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://twitter.com/PyCampES">
-                  <i class="fab fa-twitter-square fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://www.instagram.com/pycampes/">
-                  <i class="fab fa-instagram fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item">
-                <a target="_blank" href="https://pycampes.slack.com">
-                  <i class="fab fa-slack fa-2x fa-fw"></i>
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="row mt-3">
-          <div class="col-12 h-100 text-center my-auto ">
-            <ul class="nav justify-content-center">
-              <li class="nav-item">
-                <a class="nav-link active" href="./index.html">Inicio</a>
-              </li>
-              <li class="nav-item">
-                <a
-                  class="nav-link"
-                  href="./diversity.html"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Código de conducta
-                </a>
-              </li>
-              <li class="nav-item">
-                <a
-                  class="nav-link"
-                  href="./previous_editions.html"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Ediciones anteriores
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </footer>
-    <!-- Make sure you put this AFTER Leaflet's CSS -->
-    <script
-      src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
-      integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
-      crossorigin=""
-    ></script>
-    <script src="../src/index.js"></script>
-    <script
-      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-      integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
-      integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
-      crossorigin="anonymous"
-    ></script>
-  </body>
-</html>
+
+{% endblock %}
+
+{% block extra_footer %}
+<script src="../src/index.js"></script>
+{% endblock %}

--- a/public/index.njk
+++ b/public/index.njk
@@ -701,5 +701,12 @@
 {% endblock %}
 
 {% block extra_footer %}
+    <!-- Make sure you put this AFTER Leaflet's CSS -->
+    <script
+      src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
+      integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
+      crossorigin=""
+    ></script>
+
 <script src="../src/index.js"></script>
 {% endblock %}

--- a/public/index.njk
+++ b/public/index.njk
@@ -344,7 +344,6 @@
                   sección de
                   <a
                     href="previous_editions.njk"
-                    target="_blank"
                     ><b>ediciones anteriores</b></a
                   >.
                 </p>

--- a/public/layout.njk
+++ b/public/layout.njk
@@ -166,7 +166,6 @@
                 <a
                   class="nav-link"
                   href="./diversity.njk"
-                  target="_blank"
                   rel="noopener noreferrer"
                 >
                   Código de conducta

--- a/public/layout.njk
+++ b/public/layout.njk
@@ -186,13 +186,6 @@
         </div>
       </div>
     </footer>
-    <!-- Make sure you put this AFTER Leaflet's CSS -->
-    <script
-      src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
-      integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
-      crossorigin=""
-    ></script>
-
     {% block extra_footer %}
     {% endblock %}
 

--- a/public/layout.njk
+++ b/public/layout.njk
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <meta name="robots" content="index,follow" />
+    <meta name="description" content="PyCamp España" />
+    <link rel="canonical" href="https://pycamp.es/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="PyCamp.ES" />
+    <meta property="og:title" content="PyCamp.ES" />
+    <meta property="og:description" content="PyCamp España" />
+    <meta property="og:image:width" content="500" />
+    <meta property="og:image:height" content="300" />
+    <meta property="og:price:amount" content="220" />
+    <meta property="og:price:currency" content="EUR" />
+    <meta name="twitter:card" content="summary_large_image" />
+
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="shortcut icon" href="/images/camp.svg" />
+
+    {% block extra_head %}
+    {% endblock %}
+
+    <script
+      src="https://kit.fontawesome.com/738e427f6d.js"
+      crossorigin="anonymous"
+    ></script>
+
+    <title>{% block title %}PyCamp España{% endblock %}</title>
+  </head>
+
+  <body>
+    <!-- Navigation -->
+    <nav
+      class="navbar navbar-expand-lg navbar-light bg-primary sticky-top py-3"
+    >
+      <div class="container">
+        <a class="navbar-brand" href="/"
+          ><img src="images/pycamp-logo2.png" width="200"
+        /></a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-toggle="collapse"
+          data-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav ml-auto">
+            <li class="nav-item">
+              <a class="nav-link" href="/#faq">¿Qué es un PyCamp?</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/#projects">Proyectos</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/#what-to-bring">¿Qué llevo?</a>
+            </li>
+            <li class="nav-item">
+              <a
+                class="nav-link"
+                href="./diversity.njk"
+                rel="noopener noreferrer"
+              >
+                Código de conducta
+              </a>
+            </li>
+            <li class="nav-item">
+              <ul class="nav-link list-inline mb-0 text-center">
+                <li class="list-inline-item mr-3">
+                  <a target="_blank" href="mailto:pycampes@gmail.com">
+                    <i class="text-secondary far fa-envelope"></i>
+                  </a>
+                </li>
+                <li class="list-inline-item mr-3">
+                  <a target="_blank" href="https://t.me/pycampes">
+                    <i class="text-secondary fab fa-telegram"></i>
+                  </a>
+                </li>
+                <li class="list-inline-item mr-3">
+                  <a target="_blank" href="https://www.facebook.com/pycampes">
+                    <i class="text-secondary fab fa-facebook"></i>
+                  </a>
+                </li>
+                <li class="list-inline-item mr-3">
+                  <a target="_blank" href="https://twitter.com/PyCampES">
+                    <i class="text-secondary fab fa-twitter-square"></i>
+                  </a>
+                </li>
+                <li class="list-inline-item mr-3">
+                  <a target="_blank" href="https://www.instagram.com/pycampes/">
+                    <i class="text-secondary fab fa-instagram"></i>
+                  </a>
+                </li>
+                <li class="list-inline-item">
+                  <a target="_blank" href="https://pycampes.slack.com">
+                    <i class=" text-secondary fab fa-slack"></i>
+                  </a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    {% block content %}
+    {% endblock %}
+
+    <!-- Footer -->
+    <footer class="footer bg-secondary">
+      <div class="container py-5">
+        <div class="row">
+          <div class="col-12 h-100 text-center my-auto">
+            <ul class="list-inline mb-0">
+              <li class="list-inline-item mr-3">
+                <a target="_blank" href="mailto:pycampes@gmail.com">
+                  <i class="far fa-envelope fa-2x fa-fw"></i>
+                </a>
+              </li>
+              <li class="list-inline-item mr-3">
+                <a target="_blank" href="https://t.me/pycampes">
+                  <i class="fab fa-telegram fa-2x fa-fw"></i>
+                </a>
+              </li>
+              <li class="list-inline-item mr-3">
+                <a target="_blank" href="https://www.facebook.com/pycampes">
+                  <i class="fab fa-facebook fa-2x fa-fw"></i>
+                </a>
+              </li>
+              <li class="list-inline-item mr-3">
+                <a target="_blank" href="https://twitter.com/PyCampES">
+                  <i class="fab fa-twitter-square fa-2x fa-fw"></i>
+                </a>
+              </li>
+              <li class="list-inline-item mr-3">
+                <a target="_blank" href="https://www.instagram.com/pycampes/">
+                  <i class="fab fa-instagram fa-2x fa-fw"></i>
+                </a>
+              </li>
+              <li class="list-inline-item">
+                <a target="_blank" href="https://pycampes.slack.com">
+                  <i class="fab fa-slack fa-2x fa-fw"></i>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="row mt-3">
+          <div class="col-12 h-100 text-center my-auto ">
+            <ul class="nav justify-content-center">
+              <li class="nav-item">
+                <a class="nav-link active" href="#">Inicio</a>
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  href="./diversity.njk"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Código de conducta
+                </a>
+              </li>
+              <li class="nav-item">
+                <a
+                  class="nav-link"
+                  href="./previous_editions.njk"
+                  rel="noopener noreferrer"
+                >
+                  Ediciones anteriores
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <!-- Make sure you put this AFTER Leaflet's CSS -->
+    <script
+      src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
+      integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
+      crossorigin=""
+    ></script>
+
+    {% block extra_footer %}
+    {% endblock %}
+
+    <script
+      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
+      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+      integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
+      integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/public/layout.njk
+++ b/public/layout.njk
@@ -189,20 +189,8 @@
     {% block extra_footer %}
     {% endblock %}
 
-    <script
-      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-      integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
-      integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
-      crossorigin="anonymous"
-    ></script>
+    {# Bug in Parcel forces us to include the extra footer this way #}
+    {% include "extra_footer.html" %}
+
   </body>
 </html>

--- a/public/previous_editions.njk
+++ b/public/previous_editions.njk
@@ -1,43 +1,15 @@
-<!DOCTYPE html>
-<html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta name="theme-color" content="#000000" />
-    <meta name="robots" content="index,follow" />
-    <meta name="description" content="Pycamp es. Campamento Python España" />
-    <link rel="canonical" href="https://pycamp.es/" />
+{% extends 'layout.njk' %}
 
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Pycampes" />
-    <meta property="og:title" content="PyCamp.ES" />
-    <meta property="og:description" content="Campamento Python España" />
-    <meta property="og:image:width" content="500" />
-    <meta property="og:image:height" content="300" />
-    <meta property="og:price:amount" content="" />
-    <meta property="og:price:currency" content="EUR" />
-    <meta name="twitter:card" content="summary_large_image" />
+{% block title %}
+PyCamp España: Ediciones anteriores
+{% endblock %}
 
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="shortcut icon" href="/images/camp.svg" />
-
-    <script
-      src="https://kit.fontawesome.com/738e427f6d.js"
-      crossorigin="anonymous"
-    ></script>
-
-    <title>PyCamp España: Ediciones Anteriores</title>
-  </head>
-
-  <body>
+{% block content %}
     <section>
       <div class="container">
         <div class="row justify-content-center">
           <div class="col col-12">
-            <h1 class="display-3 text-center">
+            <h1 class="text-primary text-center section-title pb-4" style="padding-top: 50px;">
               Ediciones anteriores
             </h1>
 
@@ -250,82 +222,8 @@
         </div>
       </div>
     </section>
-    <!-- Footer -->
-    <footer class="footer bg-secondary">
-      <div class="container py-5">
-        <div class="row">
-          <div class="col-12 h-100 text-center my-auto">
-            <ul class="list-inline mb-0">
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="mailto:pycampes@gmail.com">
-                  <i class="far fa-envelope fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://t.me/pycampes">
-                  <i class="fab fa-telegram fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://www.facebook.com/pycampes">
-                  <i class="fab fa-facebook fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://twitter.com/PyCampES">
-                  <i class="fab fa-twitter-square fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item mr-3">
-                <a target="_blank" href="https://www.instagram.com/pycampes/">
-                  <i class="fab fa-instagram fa-2x fa-fw"></i>
-                </a>
-              </li>
-              <li class="list-inline-item">
-                <a target="_blank" href="https://pycampes.slack.com">
-                  <i class="fab fa-slack fa-2x fa-fw"></i>
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="row mt-3">
-          <div class="col-12 h-100 text-center my-auto ">
-            <ul class="nav justify-content-center">
-              <li class="nav-item">
-                <a class="nav-link" href="./index.html">Inicio</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="./diversity.html">
-                  Código de conducta
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="./previous_editions.html">
-                  Ediciones Anteriores
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </footer>
+{% endblock %}
 
-    <script src="../src/previousEditions.js"></script>
-    <script
-      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-      integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
-      integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
-      crossorigin="anonymous"
-    ></script>
-  </body>
-</html>
+{% block extra_footer %}
+<script src="../src/previousEditions.js"></script>
+{% endblock %}


### PR DESCRIPTION
This PR introduces a new dependency: nunjucks, https://mozilla.github.io/nunjucks/

Nunjucks allows us to use templates to generate the pages. This way, we can have the same look and feel in Ediciones anteriores, Código de Conducta y el mismo Home de la página de una forma fácil y sin repetir código.